### PR TITLE
Improve timer background persistence

### DIFF
--- a/src/lib/stores/timer.ts
+++ b/src/lib/stores/timer.ts
@@ -17,6 +17,7 @@ export const interval = writable<number | undefined>(undefined);
 export const timer = writable<number>(1800);
 export const isWorking = writable<boolean>(true);
 export const isRunning = writable<boolean>(false);
+export const endTime = writable<number | null>(null);
 export const workingTime = writable<number>(1800);
 export const breakTime = writable<number>(300);
 export const pomodoroCount = writable<number>(
@@ -26,6 +27,28 @@ pomodoroCount.subscribe((count) => {
 	window.localStorage.setItem("pomodoroCount", count.toString());
 });
 export const alarmVolume = writable<number>(0.5);
+
+// Cargar estado persistente del temporizador
+if (typeof window !== 'undefined') {
+    const savedEnd = window.localStorage.getItem('timerEnd');
+    const savedType = window.localStorage.getItem('timerType');
+
+    if (savedEnd && savedType) {
+        const end = parseInt(savedEnd, 10);
+        if (end > Date.now()) {
+            endTime.set(end);
+            isWorking.set(savedType === 'work');
+            const remaining = Math.ceil((end - Date.now()) / 1000);
+            timer.set(remaining);
+            isRunning.set(true);
+            const newInterval = setInterval(updateTime, 1000) as unknown as number;
+            interval.set(newInterval);
+        } else {
+            window.localStorage.removeItem('timerEnd');
+            window.localStorage.removeItem('timerType');
+        }
+    }
+}
 
 export const timerDisplay = derived(timer, $timer => {
 	const hours = Math.floor($timer / 3600);
@@ -47,22 +70,31 @@ export function setTimer(time: number) {
 }
 
 export function updateTime() {
-	let currentTimer = get(timer);
-	currentTimer -= 1;
-	timer.set(currentTimer);
+        const target = get(endTime);
+        if (target === null) return;
 
-	if (currentTimer === 0) {
-		nextTimer();
-	}
+        const remaining = Math.ceil((target - Date.now()) / 1000);
+        timer.set(remaining);
+
+        if (remaining <= 0) {
+                nextTimer();
+        }
 }
 
 export function startTimer() {
-	const currentInterval = get(interval);
-	if (currentInterval) clearInterval(currentInterval);
+        const currentInterval = get(interval);
+        if (currentInterval) clearInterval(currentInterval);
 
-	const newInterval = setInterval(updateTime, 1000) as unknown as number;
-	interval.set(newInterval);
-	isRunning.set(true);
+        const end = Date.now() + get(timer) * 1000;
+        endTime.set(end);
+        if (typeof window !== 'undefined') {
+                window.localStorage.setItem('timerEnd', end.toString());
+                window.localStorage.setItem('timerType', get(isWorking) ? 'work' : 'break');
+        }
+
+        const newInterval = setInterval(updateTime, 1000) as unknown as number;
+        interval.set(newInterval);
+        isRunning.set(true);
 
 	// Comunicar con el Service Worker
 	if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
@@ -75,10 +107,15 @@ export function startTimer() {
 }
 
 export function stopTimer() {
-	const currentInterval = get(interval);
-	if (currentInterval) clearInterval(currentInterval);
-	interval.set(undefined);
-	isRunning.set(false);
+        const currentInterval = get(interval);
+        if (currentInterval) clearInterval(currentInterval);
+        interval.set(undefined);
+        isRunning.set(false);
+        endTime.set(null);
+        if (typeof window !== 'undefined') {
+                window.localStorage.removeItem('timerEnd');
+                window.localStorage.removeItem('timerType');
+        }
 
 	// Comunicar con el Service Worker
 	if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
@@ -115,35 +152,46 @@ export function nextTimer() {
 		console.error(error);
 	}
 
-	if (get(isWorking)) {
-		// Incrementamos el contador de pomodoros completados
-		pomodoroCount.update((count) => count + 1)
-		// Guardamos el contador en localStorage
-		window.localStorage.setItem("pomodoroCount", get(pomodoroCount).toString());
-		setTimer(get(breakTime));
-		isWorking.set(false);
-	} else {
-		setTimer(get(workingTime));
-		isWorking.set(true);
-	}
+        if (get(isWorking)) {
+                // Incrementamos el contador de pomodoros completados
+                pomodoroCount.update((count) => count + 1)
+                // Guardamos el contador en localStorage
+                window.localStorage.setItem("pomodoroCount", get(pomodoroCount).toString());
+                setTimer(get(breakTime));
+                isWorking.set(false);
+        } else {
+                setTimer(get(workingTime));
+                isWorking.set(true);
+        }
 
-	// Si el temporizador estaba en marcha, comenzamos el nuevo temporizador
-	// también en el Service Worker
-	if (get(isRunning)) {
-		if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
-			navigator.serviceWorker.controller.postMessage({
-				action: 'START_TIMER',
-				duration: get(timer),
-				type: get(isWorking) ? 'work' : 'break'
-			});
-		}
-	}
+        // Si el temporizador estaba en marcha, comenzamos el nuevo temporizador
+        // también en el Service Worker
+        if (get(isRunning)) {
+                const newEnd = Date.now() + get(timer) * 1000;
+                endTime.set(newEnd);
+                if (typeof window !== 'undefined') {
+                        window.localStorage.setItem('timerEnd', newEnd.toString());
+                        window.localStorage.setItem('timerType', get(isWorking) ? 'work' : 'break');
+                }
+                if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+                        navigator.serviceWorker.controller.postMessage({
+                                action: 'START_TIMER',
+                                duration: get(timer),
+                                type: get(isWorking) ? 'work' : 'break'
+                        });
+                }
+        }
 }
 
 // Función para actualizar el timer desde el Service Worker
 export function syncTimerWithServiceWorker(timeLeft: number, isActive: boolean, isWork: boolean) {
-	// Actualizar el tiempo restante
-	timer.set(timeLeft);
+        // Actualizar el tiempo restante
+        timer.set(timeLeft);
+        endTime.set(Date.now() + timeLeft * 1000);
+        if (typeof window !== 'undefined') {
+                window.localStorage.setItem('timerEnd', (Date.now() + timeLeft * 1000).toString());
+                window.localStorage.setItem('timerType', isWork ? 'work' : 'break');
+        }
 
 	// Actualizar el estado de trabajo/descanso
 	isWorking.set(isWork);


### PR DESCRIPTION
## Summary
- persist target timestamp in localStorage
- use the stored end time to keep timer running while the page is inactive

## Testing
- `npm run check` *(fails: svelte-check not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406aae5710832aa3a714a8ae35482f