### PR TITLE
Fix service worker asset caching

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -3,8 +3,8 @@ const CACHE_NAME = 'pomodoro-app-v1';
 const urlsToCache = [
   '/',
   '/index.html',
-  '/src/app.css',
-  '/src/main.ts',
+  '/src/app.css', // replaced with bundle during build
+  '/src/main.ts', // replaced with bundle during build
   '/imgs/icons/tomato.png',
   '/imgs/icons/maskable_icon.png',
   '/sounds/alarm.wav',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,41 @@
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+function injectSwAssets() {
+  return {
+    name: 'inject-sw-assets',
+    apply: 'build',
+    async closeBundle() {
+      try {
+        const manifestPath = path.resolve('dist/.vite/manifest.json')
+        const data = await fs.readFile(manifestPath, 'utf8')
+        const manifest = JSON.parse(data)
+        const entry = manifest['index.html']
+        if (!entry) return
+
+        const jsFile = '/' + entry.file
+        const cssFile = entry.css && entry.css.length ? '/' + entry.css[0] : null
+
+        const swPath = path.resolve('dist/service-worker.js')
+        let sw = await fs.readFile(swPath, 'utf8')
+        sw = sw.replace('/src/main.ts', jsFile)
+        if (cssFile) {
+          sw = sw.replace('/src/app.css', cssFile)
+        }
+        await fs.writeFile(swPath, sw)
+      } catch (e) {
+        console.error('Failed to inject service worker asset URLs', e)
+      }
+    }
+  }
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [svelte(), injectSwAssets()],
+  build: {
+    manifest: true,
+  }
 })


### PR DESCRIPTION
## Summary
- note dev assets replaced during build
- inject hashed asset urls from Vite build manifest

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68406da0c170832a827ebec4f712df48